### PR TITLE
Match alignment characters literally

### DIFF
--- a/plugin/lion.vim
+++ b/plugin/lion.vim
@@ -93,12 +93,13 @@ endfunction
 function! s:match_pos(mode, line, char, count)
 	" Get the line as if it had tabs instead of spaces
 	let line = s:tabs2spaces(a:line)
+	let pattern = escape(a:char, '^$.')
 	if a:mode == 'right'
-		let virtual_pos = match(line, a:char, 0, a:count)
-		let real_pos = match(a:line, a:char, 0, a:count)
+		let virtual_pos = match(line, pattern, 0, a:count)
+		let real_pos = match(a:line, pattern, 0, a:count)
 	elseif a:mode == 'left'
-		let virtual_pos = s:first_non_ws_after(line, a:char, a:count)
-		let real_pos = s:first_non_ws_after(a:line, a:char, a:count)
+		let virtual_pos = s:first_non_ws_after(line, pattern, a:count)
+		let real_pos = s:first_non_ws_after(a:line, pattern, a:count)
 	endif
 	return [real_pos, virtual_pos]
 endfunction
@@ -127,8 +128,8 @@ function! s:tabs2spaces(line, ...)
 endfunction
 
 " Get the first non-whitespace after [count] instances of [char]
-function! s:first_non_ws_after(line, char, count)
-	let char_pos = match(a:line, a:char, 0, a:count)
+function! s:first_non_ws_after(line, pattern, count)
+	let char_pos = match(a:line, a:pattern, 0, a:count)
 	if char_pos == -1
 		return -1
 	else


### PR DESCRIPTION
Escape `^`, `$` and `.` to match them literally
Enables commands like `glip.`

Closes #3
