### PR TITLE
Make alignments by pattern repeatable

### DIFF
--- a/plugin/lion.vim
+++ b/plugin/lion.vim
@@ -99,7 +99,11 @@ function! s:align(mode, type, vis, align_char)
 		endif
 	endfor
 
-	silent! call repeat#set("\<Plug>LionRepeat".align_pattern)
+	if align_pattern[0] == '/'
+		silent! call repeat#set("\<Plug>LionRepeat".align_pattern."")
+	else
+		silent! call repeat#set("\<Plug>LionRepeat".align_pattern)
+	endif
 endfunction
 
 function! s:getpos(start, end, mode)


### PR DESCRIPTION
Currently repeating a command like `glip/=` by pressing `.` would still require pressing `<CR>` to confirm the last pattern `=` again.

This pull request appends the missing literal `<CR>` to the repetition string to make alignments by patterns repeatable.
