### PR TITLE
Add option to limit the width of aligned fields

### DIFF
--- a/doc/lion.txt
+++ b/doc/lion.txt
@@ -57,6 +57,8 @@ Mappings can be configured with the following options:
   g:lion_squeeze_spaces   Whether to squeeze extra spaces    0
   g:lion_map_right        Mapping for right-align operator   gl
   g:lion_map_left         Mapping for left-align operator    gL
+  g:lion_max_length       Maximum length between any two     0 (no limit)
+                          alignment characters
 
 ISSUES AND TODO                                 *lion-issues* *lion-todo*
 

--- a/plugin/lion.vim
+++ b/plugin/lion.vim
@@ -80,7 +80,7 @@ function! s:align(mode, type, vis, align_char)
 		endif
 
 		" Align for each character up to count or maximum occurrences
-        let prev_longest = 0
+		let prev_longest = 0
 		let iteration = 1
 		while 1
 			let line_virtual_pos = [] " Keep track of positions
@@ -105,9 +105,9 @@ function! s:align(mode, type, vis, align_char)
 				let longest = max([longest, virtual_pos])
 			endfor
 
-            if s:lion_max_length > 0
-                let longest = min([longest, prev_longest + s:lion_max_length])
-            endif
+			if s:lion_max_length > 0
+				let longest = min([longest, prev_longest + s:lion_max_length])
+			endif
 
 			" Align each line according to the longest
 			for line_number in range(start_line, end_line)
@@ -127,7 +127,7 @@ function! s:align(mode, type, vis, align_char)
 				break
 			endif
 			let iteration += 1
-            let prev_longest = longest
+			let prev_longest = longest
 		endwhile
 
 		if align_pattern[0] ==# '/'

--- a/plugin/lion.vim
+++ b/plugin/lion.vim
@@ -5,6 +5,7 @@
 let s:count = 1
 
 let s:lion_prompt = get(g:, 'lion_prompt', 'Pattern [/]: ')
+let s:lion_max_length = get(g:, 'lion_max_length', 0)
 
 function! s:command(func, ...)
 	let s:count = v:count
@@ -79,6 +80,7 @@ function! s:align(mode, type, vis, align_char)
 		endif
 
 		" Align for each character up to count or maximum occurrences
+        let prev_longest = 0
 		let iteration = 1
 		while 1
 			let line_virtual_pos = [] " Keep track of positions
@@ -103,6 +105,10 @@ function! s:align(mode, type, vis, align_char)
 				let longest = max([longest, virtual_pos])
 			endfor
 
+            if s:lion_max_length > 0
+                let longest = min([longest, prev_longest + s:lion_max_length])
+            endif
+
 			" Align each line according to the longest
 			for line_number in range(start_line, end_line)
 				let line_str = getline(line_number)
@@ -121,6 +127,7 @@ function! s:align(mode, type, vis, align_char)
 				break
 			endif
 			let iteration += 1
+            let prev_longest = longest
 		endwhile
 
 		if align_pattern[0] ==# '/'


### PR DESCRIPTION
Added `lion_max_length` option to limit the length between two alignment characters. Useful when working with tabular data, where one row can have very long columns that will throw off alignment.

Before, working on a tab-separated file and using `glG<Tab>`:
![image](https://user-images.githubusercontent.com/7876996/62253780-e8eaeb00-b3ab-11e9-9fb7-a43678852699.png)

After, setting `g:lion_max_length = 40` and applying the same operation:
![image](https://user-images.githubusercontent.com/7876996/62253824-04ee8c80-b3ac-11e9-9996-956409cc0709.png)